### PR TITLE
Bc 17 store recently played songs

### DIFF
--- a/commandHandler.js
+++ b/commandHandler.js
@@ -1,79 +1,78 @@
-const fs = require("fs");
-const Discord = require("discord.js");
-const MusicPlayer = require("./commands/music/MusicPlayer.js"); // Singleton handling music player/queue
+const fs = require('fs');
+const Discord = require('discord.js');
+const MusicPlayer = require('./commands/music/MusicPlayer.js'); // Singleton handling music player/queue
 
-const musicHandler = data => {
-  let { command, client, message, args } = data;
-  if (command === "bruhplay") MusicPlayer.play(client, message, args);
-  else if (command === "bruhskip") MusicPlayer.skip(client, message, args);
-  else if (command === "bruhstop") MusicPlayer.stop(client, message, args);
-  else if (command === "bruhrepeat") MusicPlayer.repeat(client, message, args);
-  else if (command === "bruhpause") MusicPlayer.pause(client, message, args);
-  else if (command === "bruhresume") MusicPlayer.resume(client, message, args);
-  else if (command === "bruhnext") MusicPlayer.next(client, message, args);
+const musicHandler = (data) => {
+	let { command, client, message, args } = data;
+	if (command === 'bruhplay') MusicPlayer.play(client, message, args);
+	else if (command === 'bruhskip') MusicPlayer.skip(client, message, args);
+	else if (command === 'bruhstop') MusicPlayer.stop(client, message, args);
+	else if (command === 'bruhrepeat') MusicPlayer.repeat(client, message, args);
+	else if (command === 'bruhpause') MusicPlayer.pause(client, message, args);
+	else if (command === 'bruhresume') MusicPlayer.resume(client, message, args);
+	else if (command === 'bruhnext') MusicPlayer.next(client, message, args);
+	else if (command === 'bruhqueue') MusicPlayer.queue(client, message, args);
 };
 
 const handler = () => {
-  const client = require("./bot.js");
-  client.commands = new Discord.Collection();
-  client.skills = new Discord.Collection();
+	const client = require('./bot.js');
+	client.commands = new Discord.Collection();
+	client.skills = new Discord.Collection();
 
-  const prefixCommandFiles = fs
-    .readdirSync("./commands/prefix")
-    .filter(file => file.endsWith(".js"));
+	const prefixCommandFiles = fs.readdirSync('./commands/prefix').filter((file) => file.endsWith('.js'));
 
-  for (const file of prefixCommandFiles) {
-    const command = require(`./commands/prefix/${file}`);
-    client.commands.set(command.name, command);
-  }
+	for (const file of prefixCommandFiles) {
+		const command = require(`./commands/prefix/${file}`);
+		client.commands.set(command.name, command);
+	}
 
-  const hears = require("./commands/dynamic/hears");
+	const hears = require('./commands/dynamic/hears');
 
-  client.once("ready", () => {
-    client.user.setStatus("online");
-    const statusText = "The Steam Summer Sale Provides";
-    client.user.setActivity(statusText, {
-      type: "PLAYING",
-      url: "https://github.com/cdw-2014/bruh-counter"
-    });
-    console.log("Ready!");
-  });
+	client.once('ready', () => {
+		client.user.setStatus('online');
+		const statusText = 'The Steam Summer Sale Provides';
+		client.user.setActivity(statusText, {
+			type : 'PLAYING',
+			url  : 'https://github.com/cdw-2014/bruh-counter'
+		});
+		console.log('Ready!');
+	});
 
-  //client.on("debug", console.log);
+	//client.on("debug", console.log);
 
-  client.on("message", message => {
-    if (message.author.bot) return;
+	client.on('message', (message) => {
+		if (message.author.bot) return;
 
-    const regex = /[^\s"]+|"([^"]*)"/gi;
-    var args = [];
+		const regex = /[^\s"]+|"([^"]*)"/gi;
+		var args = [];
 
-    do {
-      var match = regex.exec(message.content);
-      if (match != null) {
-        args.push(match[1] ? match[1] : match[0]);
-      }
-    } while (match != null);
+		do {
+			var match = regex.exec(message.content);
+			if (match != null) {
+				args.push(match[1] ? match[1] : match[0]);
+			}
+		} while (match != null);
 
-    let command;
-    if (args.length) {
-      command = args.shift().toLowerCase();
-    }
+		let command;
+		if (args.length) {
+			command = args.shift().toLowerCase();
+		}
 
-    if (command && require("./constants/musicCommands").includes(command)) {
-      musicHandler({ command, client, message, args });
-    } else if (command && !client.commands.has(command)) {
-      hears.execute(client, message, args);
-    } else if (command) {
-      try {
-        client.commands.get(command).execute(client, message, args);
-      } catch (error) {
-        console.error(error);
-        message.reply("there was an error trying to execute that command!");
-      }
-    }
-  });
+		if (command && require('./constants/musicCommands').includes(command)) {
+			musicHandler({ command, client, message, args });
+		} else if (command && !client.commands.has(command)) {
+			hears.execute(client, message, args);
+		} else if (command) {
+			try {
+				client.commands.get(command).execute(client, message, args);
+			} catch (error) {
+				console.error(error);
+				message.reply('there was an error trying to execute that command!');
+			}
+		}
+	});
 
-  client.login(process.env.DISCORD_TOKEN).catch(console.error);
+	client.login(process.env.DISCORD_TOKEN).catch(console.error);
 };
 
 module.exports.handler = handler;

--- a/commands/music/MusicPlayer.js
+++ b/commands/music/MusicPlayer.js
@@ -25,7 +25,7 @@ const dispatchSong = (connection, message, args) => {
 	server.dispatcher.on('finish', async () => {
 		const finishedSong = server.queue.shift(); // finishedSong = URL of song that has finished playing. It is removed from the queue.
 		server.pastSongs.push(finishedSong); // finishedSong is added to pastSongs
-		const finishedSongTitle = (await ytdl.getInfo(finishedSong)).title; // finishedSongTitle = Title of finishedSong on YT
+		const finishedSongTitle = (await ytdl.getInfo(finishedSong)).videoDetails.title; // finishedSongTitle = Title of finishedSong on YT
 		message.channel.send(`\`\`\`${finishedSongTitle} has finished playing!\`\`\``); // sends message in Discord channel
 		if (server.queue[0])
 			dispatchSong(connection, message, args); // recursively dispatches next song in queue if there is more songs
@@ -57,7 +57,7 @@ const MusicPlayer = {
 			}
 		}
 
-		const title = (await ytdl.getInfo(link)).title;
+		const title = (await ytdl.getInfo(link)).videoDetails.title;
 
 		if (server.queue.length) {
 			message.channel.send(`\`\`\`${title} is #${server.queue.length} in the queue!\`\`\``);
@@ -96,7 +96,7 @@ const MusicPlayer = {
 	repeat : async (client, message, args) => {
 		if (servers[message.guild.id]) {
 			if (servers[message.guild.id].queue.length) {
-				const title = (await ytdl.getInfo(servers[message.guild.id].queue[0])).title;
+				const title = (await ytdl.getInfo(servers[message.guild.id].queue[0])).videoDetails.title;
 				message.channel.send(
 					`\`\`\`${title} has been inserted into the queue! It will play again after this!\`\`\``
 				);
@@ -130,7 +130,7 @@ const MusicPlayer = {
 						link = results.videos[0].url;
 					}
 				}
-				const title = (await ytdl.getInfo(link)).title;
+				const title = (await ytdl.getInfo(link)).videoDetails.title;
 				message.channel.send(`\`\`\`${title} has been inserted into the queue! It will play after this!\`\`\``);
 				servers[message.guild.id].queue.splice(1, 0, link);
 			}
@@ -146,13 +146,13 @@ const MusicPlayer = {
 
 					for (const song of servers[message.guild.id].pastSongs) {
 						const songInfo = await ytdl.getInfo(song);
-						queueMsg += songInfo.title + '\n';
+						queueMsg += songInfo.videoDetails.title + '\n';
 					}
 				}
 
 				if (servers[message.guild.id].queue.length) {
 					queueMsg += `Currently Playing: ${(await ytdl.getInfo(servers[message.guild.id].queue[0]))
-						.title}\n`;
+						.videoDetails.title}\n`;
 				}
 
 				if (servers[message.guild.id].queue.length > 1) {
@@ -160,7 +160,7 @@ const MusicPlayer = {
 
 					for (const song of servers[message.guild.id].queue.slice(1)) {
 						const songInfo = await ytdl.getInfo(song);
-						queueMsg += songInfo.title + '\n';
+						queueMsg += songInfo.videoDetails.title + '\n';
 					}
 				}
 				queueMsg += `\`\`\``;

--- a/commands/music/MusicPlayer.js
+++ b/commands/music/MusicPlayer.js
@@ -74,23 +74,22 @@ const MusicPlayer = {
 	},
 	skip   : (client, message, args) => {
 		let server = servers[message.guild.id];
-		if (!server.queue || !server.queue.length)
+		if (!server || !server.queue || !server.queue.length)
 			message.reply(
 				'There is no song playing to skip! use the following command to play a song or queue additional songs while one is playing: ```bruhplay <youtube link>```'
 			);
 
-		if (server.dispatcher) server.dispatcher.end();
+		if (server && server.dispatcher) server.dispatcher.end();
 	},
 	stop   : async (client, message, args) => {
 		if (servers[message.guild.id]) {
-			// message.member.voice.channel.leave();
 			if (servers[message.guild.id].queue.length > 1) {
 				servers[message.guild.id].queue = [
 					servers[message.guild.id].queue[0]
 				];
 			}
 			await servers[message.guild.id].dispatcher.end();
-			// delete servers[message.guild.id]
+			servers[message.guild.id].pastSongs = [];
 			message.member.voice.channel.leave();
 		}
 	},

--- a/commands/music/MusicPlayer.js
+++ b/commands/music/MusicPlayer.js
@@ -148,11 +148,13 @@ const MusicPlayer = {
 						const songInfo = await ytdl.getInfo(song);
 						queueMsg += songInfo.videoDetails.title + '\n';
 					}
+					queueMsg += '----------\n';
 				}
 
 				if (servers[message.guild.id].queue.length) {
 					queueMsg += `Currently Playing: ${(await ytdl.getInfo(servers[message.guild.id].queue[0]))
 						.videoDetails.title}\n`;
+					queueMsg += '----------\n';
 				}
 
 				if (servers[message.guild.id].queue.length > 1) {

--- a/commands/music/MusicPlayer.js
+++ b/commands/music/MusicPlayer.js
@@ -136,6 +136,38 @@ const MusicPlayer = {
 				servers[message.guild.id].queue.splice(1, 0, link);
 			}
 		}
+	},
+	queue  : async (client, message, args) => {
+		if (servers[message.guild.id]) {
+			if (servers[message.guild.id].queue.length || servers[message.guild.id].pastSongs.length) {
+				let queueMsg = `\`\`\`\n`;
+
+				if (servers[message.guild.id].pastSongs.length) {
+					queueMsg += 'Recently Played:\n';
+
+					for (const song of servers[message.guild.id].pastSongs) {
+						const songInfo = await ytdl.getInfo(song);
+						queueMsg += songInfo.title + '\n';
+					}
+				}
+
+				if (servers[message.guild.id].queue.length) {
+					queueMsg += `Currently Playing: ${(await ytdl.getInfo(servers[message.guild.id].queue[0]))
+						.title}\n`;
+				}
+
+				if (servers[message.guild.id].queue.length > 1) {
+					queueMsg += 'Queued:\n';
+
+					for (const song of servers[message.guild.id].queue.slice(1)) {
+						const songInfo = await ytdl.getInfo(song);
+						queueMsg += songInfo.title + '\n';
+					}
+				}
+				queueMsg += `\`\`\``;
+				message.channel.send(queueMsg);
+			}
+		}
 	}
 };
 

--- a/commands/music/MusicPlayer.js
+++ b/commands/music/MusicPlayer.js
@@ -1,136 +1,142 @@
-const Discord = require("discord.js");
-const ytdl = require("ytdl-core");
-const yts = require("yt-search");
+const Discord = require('discord.js');
+const ytdl = require('ytdl-core');
+const yts = require('yt-search');
 
 let servers = {};
 let isPlaying = false;
 
 const isUrl = (input) => {
-  return input.includes("youtube.com");
-  // let regexp = /(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\s+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/;
-  // return regexp.test(s);
-}
+	return input.includes('youtube.com');
+	// let regexp = /(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\s+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/;
+	// return regexp.test(s);
+};
 
 const dispatchSong = (connection, message, args) => {
-  var server = servers[message.guild.id];
+	var server = servers[message.guild.id];
 
-  server.dispatcher = connection.play(
-    ytdl(server.queue[0], {
-      filter: "audioonly",
-      quality: "highestaudio",
-      volume: 0.6
-    })
-  );
+	server.dispatcher = connection.play(
+		ytdl(server.queue[0], {
+			filter  : 'audioonly',
+			quality : 'highestaudio',
+			volume  : 0.6
+		})
+	);
 
-  server.dispatcher.on("finish", async () => {
-    let info = await ytdl.getInfo(server.queue.shift());
-    const title = info.title;
-    const finishedSong = title;
-    message.channel.send(`\`\`\`${finishedSong} has finished playing!\`\`\``);
-    if (server.queue[0]) dispatchSong(connection, message, args);
-    else isPlaying = false;
-  });
+	server.dispatcher.on('finish', async () => {
+		const finishedSong = server.queue.shift(); // finishedSong = URL of song that has finished playing. It is removed from the queue.
+		server.pastSongs.push(finishedSong); // finishedSong is added to pastSongs
+		const finishedSongTitle = (await ytdl.getInfo(finishedSong)).title; // finishedSongTitle = Title of finishedSong on YT
+		message.channel.send(`\`\`\`${finishedSongTitle} has finished playing!\`\`\``); // sends message in Discord channel
+		if (server.queue[0])
+			dispatchSong(connection, message, args); // recursively dispatches next song in queue if there is more songs
+		else isPlaying = false; // otherwise sets isPlaying flag to false.
+	});
 };
 
 const MusicPlayer = {
-  play: async (client, message, args) => {
-    if (!args.length) return;
+	play   : async (client, message, args) => {
+		if (!args.length) return;
 
-    if (!servers[message.guild.id])
-      servers[message.guild.id] = {
-        queue: [],
-        dispatcher: null
-      };
+		if (!servers[message.guild.id])
+			servers[message.guild.id] = {
+				queue      : [],
+				pastSongs  : [],
+				dispatcher : null
+			};
 
-    let server = servers[message.guild.id];
+		let server = servers[message.guild.id];
 
-    let link = "";
+		let link = '';
 
-    if (isUrl(args[0])) {
-      link = args[0]
-    } else {
-      let results = await yts(args.join(" "));
-      if (results.videos && results.videos.length > 0) {
-        link = results.videos[0].url;
-      }
-    }
+		if (isUrl(args[0])) {
+			link = args[0];
+		} else {
+			let results = await yts(args.join(' '));
+			if (results.videos && results.videos.length > 0) {
+				link = results.videos[0].url;
+			}
+		}
 
-    const title = (await ytdl.getInfo(link)).title
+		const title = (await ytdl.getInfo(link)).title;
 
-    if (server.queue.length) {
-      message.channel.send(`\`\`\`${title} is #${server.queue.length} in the queue!\`\`\``)
-    }
+		if (server.queue.length) {
+			message.channel.send(`\`\`\`${title} is #${server.queue.length} in the queue!\`\`\``);
+		}
 
-    server.queue.push(link);
+		server.queue.push(link);
 
-    if (!message.guild.voiceConnection && !isPlaying) {
-      message.member.voice.channel.join().then(connection => {
-        isPlaying = true;
-        dispatchSong(connection, message, args);
-      });
-    }
-  },
-  skip: (client, message, args) => {
-    let server = servers[message.guild.id];
-    if (!server.queue || !server.queue.length)
-      message.reply(
-        "There is no song playing to skip! use the following command to play a song or queue additional songs while one is playing: ```bruhplay <youtube link>```"
-      );
+		if (!message.guild.voiceConnection && !isPlaying) {
+			message.member.voice.channel.join().then((connection) => {
+				isPlaying = true;
+				dispatchSong(connection, message, args);
+			});
+		}
+	},
+	skip   : (client, message, args) => {
+		let server = servers[message.guild.id];
+		if (!server.queue || !server.queue.length)
+			message.reply(
+				'There is no song playing to skip! use the following command to play a song or queue additional songs while one is playing: ```bruhplay <youtube link>```'
+			);
 
-    if (server.dispatcher) server.dispatcher.end();
-  },
-  stop: async (client, message, args) => {
-    if (servers[message.guild.id]) {
-      // message.member.voice.channel.leave();
-      if (servers[message.guild.id].queue.length > 1) {
-        servers[message.guild.id].queue = [servers[message.guild.id].queue[0]]
-      }
-      await servers[message.guild.id].dispatcher.end();
-      // delete servers[message.guild.id]
-      message.member.voice.channel.leave();
-    }
-  },
-  repeat: async (client, message, args) => {
-    if (servers[message.guild.id]) {
-      if (servers[message.guild.id].queue.length) {
-        const title = (await ytdl.getInfo(servers[message.guild.id].queue[0])).title
-        message.channel.send(`\`\`\`${title} has been inserted into the queue! It will play again after this!\`\`\``)
-        servers[message.guild.id].queue.splice(1, 0, servers[message.guild.id].queue[0])
-      }
-    }
-  },
-  pause: (client, message, args) => {
-    if (servers[message.guild.id]) {
-      if (servers[message.guild.id].queue.length) {
-        servers[message.guild.id].dispatcher.pause();
-      }
-    }
-  },
-  resume: (client, message, args) => {
-    if (servers[message.guild.id]) {
-      if (servers[message.guild.id].queue.length) {
-        servers[message.guild.id].dispatcher.resume();
-      }
-    }
-  },
-  next: async (client, message, args) => {
-    if (servers[message.guild.id]) {
-      if (servers[message.guild.id].queue.length) {
-        let link = "";
-        if (isUrl(args[0])) {
-          link = args[0]
-        } else {
-          let results = await yts(args.join(" "));
-          if (results.videos && results.videos.length > 0) {
-            link = results.videos[0].url;
-          }
-        }
-        const title = (await ytdl.getInfo(link)).title
-        message.channel.send(`\`\`\`${title} has been inserted into the queue! It will play after this!\`\`\``)
-        servers[message.guild.id].queue.splice(1, 0, link)
-      }
-    }
-  }
+		if (server.dispatcher) server.dispatcher.end();
+	},
+	stop   : async (client, message, args) => {
+		if (servers[message.guild.id]) {
+			// message.member.voice.channel.leave();
+			if (servers[message.guild.id].queue.length > 1) {
+				servers[message.guild.id].queue = [
+					servers[message.guild.id].queue[0]
+				];
+			}
+			await servers[message.guild.id].dispatcher.end();
+			// delete servers[message.guild.id]
+			message.member.voice.channel.leave();
+		}
+	},
+	repeat : async (client, message, args) => {
+		if (servers[message.guild.id]) {
+			if (servers[message.guild.id].queue.length) {
+				const title = (await ytdl.getInfo(servers[message.guild.id].queue[0])).title;
+				message.channel.send(
+					`\`\`\`${title} has been inserted into the queue! It will play again after this!\`\`\``
+				);
+				servers[message.guild.id].queue.splice(1, 0, servers[message.guild.id].queue[0]);
+			}
+		}
+	},
+	pause  : (client, message, args) => {
+		if (servers[message.guild.id]) {
+			if (servers[message.guild.id].queue.length) {
+				servers[message.guild.id].dispatcher.pause();
+			}
+		}
+	},
+	resume : (client, message, args) => {
+		if (servers[message.guild.id]) {
+			if (servers[message.guild.id].queue.length) {
+				servers[message.guild.id].dispatcher.resume();
+			}
+		}
+	},
+	next   : async (client, message, args) => {
+		if (servers[message.guild.id]) {
+			if (servers[message.guild.id].queue.length) {
+				let link = '';
+				if (isUrl(args[0])) {
+					link = args[0];
+				} else {
+					let results = await yts(args.join(' '));
+					if (results.videos && results.videos.length > 0) {
+						link = results.videos[0].url;
+					}
+				}
+				const title = (await ytdl.getInfo(link)).title;
+				message.channel.send(`\`\`\`${title} has been inserted into the queue! It will play after this!\`\`\``);
+				servers[message.guild.id].queue.splice(1, 0, link);
+			}
+		}
+	}
 };
 
 Object.freeze(MusicPlayer);

--- a/constants/musicCommands.js
+++ b/constants/musicCommands.js
@@ -1,10 +1,11 @@
 module.exports = [
-  "bruhplay",
-  "bruhskip",
-  "bruhstop",
-  "bruhplaylist",
-  "bruhrepeat",
-  "bruhpause",
-  "bruhresume",
-  "bruhnext"
+	'bruhplay',
+	'bruhskip',
+	'bruhstop',
+	'bruhplaylist',
+	'bruhrepeat',
+	'bruhpause',
+	'bruhresume',
+	'bruhnext',
+	'bruhqueue'
 ];


### PR DESCRIPTION
- BC-17: added pastSongs to server and added bruhqueue command
- Fixed bug with bruhskip when there is no listening session
- Updated deprecated YTDL getinfo method

Note: With many songs in the queue, it takes a moment to execute the bruhqueue command. YTDL.getinfo should be decoupled and made its own function. Also, the song title, song length, time queued, and the queuer should be stored in the queue array to reduce the redundant calls to the API.